### PR TITLE
ci(cd): update workflow to use Google Cloud actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,13 +11,25 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
         with:
-          go-version: '1.23.0'
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-      - name: Build app
-        run: ./scripts/buildprod.sh
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Use gcloud CLI'
+        run: 'gcloud builds submit --tag us-central1-docker.pkg.dev/notely-451716/notely-ar-repo/notely:latest .'
+
+#    steps:
+#      - name: Check out code
+#        uses: actions/checkout@v4
+#
+#      - name: Set up Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: '1.23.0'
+#
+#      - name: Build app
+#        run: ./scripts/buildprod.sh


### PR DESCRIPTION
- Replaced `actions/checkout` and `setup-go` with `google-github-actions/auth` and `setup-gcloud`.
- Added Google Cloud authentication using GCP credentials.
- Updated deployment to use `gcloud builds submit` for container build and deployment.